### PR TITLE
chore : cd workflow에서 multiple jobs 에서 job 공유 문제로 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -6,15 +6,11 @@ on:
       - develop
 
 jobs:
-  push_to_docker_hub:
-    needs: application_build
+  application_build:
     runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.generate_version.outputs.new_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
 
       - name: java setting
         uses: actions/setup-java@v3
@@ -26,6 +22,27 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: application
+          path: build/libs/*.jar
+
+  push_to_docker_hub:
+    needs: application_build
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.generate_version.outputs.new_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: application
+          path: build/libs
 
       - name: Generate Version
         id: generate_version

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -6,11 +6,15 @@ on:
       - develop
 
 jobs:
-  application_build:
+  push_to_docker_hub:
+    needs: application_build
     runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.generate_version.outputs.new_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
 
       - name: java setting
         uses: actions/setup-java@v3
@@ -23,12 +27,6 @@ jobs:
           chmod +x gradlew
           ./gradlew build
 
-  push_to_docker_hub:
-    needs: application_build
-    runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.generate_version.outputs.new_version }}
-    steps:
       - name: Generate Version
         id: generate_version
         run: |
@@ -67,9 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: push_to_docker_hub
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
       - name: Run Docker container
         uses: appleboy/ssh-action@master
         env:


### PR DESCRIPTION
## 🗃 Issue

- Close #이슈번호

## 🔥 Task

- job 간 데이터 공유를 위해 artifact upload/download 사용

## 📄 Reference

- artifact 공유하는 방법
https://stackoverflow.com/questions/57498605/github-actions-share-workspace-artifacts-between-jobs
- github action은 container 기반으로 동작하며, 각 Job 실행 시 새로운 container를 생성함. 따라서 각 container간 데이터 공유를 하기 위해서는 artifact upload/download를 사용해야함
