### PR TITLE
feat: 소셜 로그인 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ out/
 .kotlin
 
 ### application.yml ###
+
+
+### rest docs ###
+**/src/main/resources/static/docs/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,13 +51,13 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
 
     // security
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    testImplementation("org.springframework.security:spring-security-test")
+//    implementation("org.springframework.boot:spring-boot-starter-security")
+//    testImplementation("org.springframework.security:spring-security-test")
 
     // kotest
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")  // Test Framework
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion") // Assertions Library
-    testImplementation("io.kotest:kotest-property:$kotestVersion") //
+    testImplementation("io.kotest:kotest-property:$kotestVersion") // Property Testing
 
     testImplementation("io.mockk:mockk:${mockkVersion}") // mockk
 
@@ -78,6 +78,9 @@ dependencies {
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testFixturesImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+
+    // webclient
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/docs/asciidoc/Auth.adoc
+++ b/src/docs/asciidoc/Auth.adoc
@@ -1,0 +1,7 @@
+[[Auth-API]]
+== Auth API
+
+[[Auth-Login]]
+=== 소셜 로그인
+
+operation::AuthControllerTest/socialLogin[snippets='http-request,path-parameters,request-fields,http-response,response-fields']

--- a/src/docs/asciidoc/Auth.adoc
+++ b/src/docs/asciidoc/Auth.adoc
@@ -1,7 +1,25 @@
 [[Auth-API]]
 == Auth API
 
-[[Auth-Login]]
-=== 소셜 로그인
+[[Auth-Login-With-Register]]
+=== 소셜 로그인시 회원가입되어 있을 때
 
-operation::AuthControllerTest/socialLogin[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+operation::AuthControllerTest/socialLoginWithRegisterUser[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+[[Auth-Login-Without-Register]]
+=== 소셜 로그인시 회원가입되어 있지 않을 때
+
+operation::AuthControllerTest/socialLoginWithUnRegisterUser[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+[[Auth-Reissue]]
+=== 토큰 재발급
+
+operation::AuthControllerTest/reissueToken[snippets='http-request,request-fields,http-response,response-fields']
+
+[[Auth-Refresh]]
+
+[[Auth-Logout]]
+=== 로그아웃
+
+operation::AuthControllerTest/logout[snippets='http-request,request-fields,http-response']
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,9 @@
+= ASAP-Backend API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+include::Auth.adoc[]

--- a/src/main/kotlin/com/asap/asapbackend/client/oauth/OAuthConfig.kt
+++ b/src/main/kotlin/com/asap/asapbackend/client/oauth/OAuthConfig.kt
@@ -1,0 +1,20 @@
+package com.asap.asapbackend.client.oauth
+
+import com.asap.asapbackend.client.oauth.kakao.KakaoSocialLoginHandler
+import com.asap.asapbackend.domain.user.domain.enum.Provider
+import com.asap.asapbackend.domain.user.domain.service.SocialLoginHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OAuthConfig(
+    private val kakaoSocialLoginHandler: KakaoSocialLoginHandler
+) {
+
+    @Bean
+    fun socialLoginHandlerMap(): Map<Provider, SocialLoginHandler>{
+        return mapOf(
+            Provider.KAKAO to kakaoSocialLoginHandler
+        )
+    }
+}

--- a/src/main/kotlin/com/asap/asapbackend/client/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/asap/asapbackend/client/oauth/kakao/KakaoOAuthClient.kt
@@ -1,0 +1,25 @@
+package com.asap.asapbackend.client.oauth.kakao
+
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+@Component
+class KakaoOAuthClient {
+
+    private val webclient = WebClient.create("https://kapi.kakao.com")
+
+    fun retrieveUserInfo(accessToken: String): KakaoUserInfo? {
+        return webclient.get()
+            .uri("/v2/user/me")
+            .header("Authorization", "Bearer $accessToken")
+            .retrieve()
+            .bodyToMono(KakaoUserInfo::class.java)
+            .block()
+    }
+
+
+    data class KakaoUserInfo(
+        val id: String
+    )
+
+}

--- a/src/main/kotlin/com/asap/asapbackend/client/oauth/kakao/KakaoSocialLoginHandler.kt
+++ b/src/main/kotlin/com/asap/asapbackend/client/oauth/kakao/KakaoSocialLoginHandler.kt
@@ -1,0 +1,17 @@
+package com.asap.asapbackend.client.oauth.kakao
+
+import com.asap.asapbackend.domain.user.domain.enum.Provider
+import com.asap.asapbackend.domain.user.domain.service.SocialLoginHandler
+import org.springframework.stereotype.Component
+
+@Component
+class KakaoSocialLoginHandler(
+    private val kakaoOAuthClient: KakaoOAuthClient
+) : SocialLoginHandler {
+    override val provider: Provider = Provider.KAKAO
+
+    override fun handle(request: SocialLoginHandler.Request): SocialLoginHandler.Response {
+        val kakaoUserInfo = kakaoOAuthClient.retrieveUserInfo(request.accessToken)?: throw IllegalAccessException("카카오 사용자 정보를 가져오는데 실패했습니다.")
+        return SocialLoginHandler.Response(kakaoUserInfo.id)
+    }
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/application/AuthService.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/application/AuthService.kt
@@ -6,7 +6,7 @@ import com.asap.asapbackend.domain.user.application.dto.SocialLogin
 import com.asap.asapbackend.domain.user.domain.enum.Provider
 import com.asap.asapbackend.domain.user.domain.service.SocialLoginHandler
 import com.asap.asapbackend.domain.user.domain.service.UserReader
-import com.asap.asapbackend.global.utils.TransactionUtils
+import com.asap.asapbackend.global.util.TransactionUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/application/AuthService.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/application/AuthService.kt
@@ -1,0 +1,45 @@
+package com.asap.asapbackend.domain.user.application
+
+import com.asap.asapbackend.domain.user.application.dto.Logout
+import com.asap.asapbackend.domain.user.application.dto.Reissue
+import com.asap.asapbackend.domain.user.application.dto.SocialLogin
+import com.asap.asapbackend.domain.user.domain.enum.Provider
+import com.asap.asapbackend.domain.user.domain.service.SocialLoginHandler
+import com.asap.asapbackend.domain.user.domain.service.UserReader
+import com.asap.asapbackend.global.utils.TransactionUtils
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+
+@Service
+class AuthService(
+    private val authHandlerMap: Map<Provider, SocialLoginHandler>,
+    private val userReader: UserReader
+) {
+
+
+    fun executeSocialLogin(socialLoginRequest: SocialLogin.Request, provider: Provider): SocialLogin.Response {
+        // TODO: 지원하지 않는 소셜 로그인일 경우 예외처리 추가하기
+        val socialLoginHandler = authHandlerMap[provider] ?: throw IllegalArgumentException("지원하지 않는 소셜 로그인입니다.")
+        val response = socialLoginHandler.handle(SocialLoginHandler.Request(socialLoginRequest.accessToken))
+        return TransactionUtils.writable { // 일부분만 트랜잭션 처리하기 위한 용도, 앞선 외부 api 호출은 트랜잭션에 포함해서는 안됨
+            // TODO: 이미 가입된 사용자인지 확인하고 가입되지 않은 사용자라면 가입을 위한 token 반환
+            return@writable userReader.findBySocialIdOrNull(response.socialId)?.let {
+                SocialLogin.Response.Success("accessToken", "refreshToken")
+            } ?: run {
+                SocialLogin.Response.UnRegistered("registerToken")
+            }
+        }
+    }
+
+    @Transactional
+    fun reissueToken(reissueRequest: Reissue.Request): Reissue.Response {
+        // TODO: 토큰 재발급 처리
+        return Reissue.Response("accessToken", "refreshToken")
+    }
+
+    @Transactional
+    fun logout(logoutRequest: Logout.Request) {
+        // TODO: 로그아웃 처리
+    }
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/Logout.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/Logout.kt
@@ -1,0 +1,9 @@
+package com.asap.asapbackend.domain.user.application.dto
+
+class Logout {
+
+    data class Request(
+        val refreshToken: String
+    )
+
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/Reissue.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/Reissue.kt
@@ -1,0 +1,13 @@
+package com.asap.asapbackend.domain.user.application.dto
+
+class Reissue {
+
+    data class Request(
+        val refreshToken: String
+    )
+
+    data class Response(
+        val accessToken: String,
+        val refreshToken: String
+    )
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/SocialLogin.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/SocialLogin.kt
@@ -1,0 +1,15 @@
+package com.asap.asapbackend.domain.user.application.dto
+
+class SocialLogin{
+
+    data class Request(
+        val accessToken: String,
+        val refreshToken: String
+    )
+
+
+    data class Response(
+        val accessToken: String,
+        val refreshToken: String
+    )
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/SocialLogin.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/application/dto/SocialLogin.kt
@@ -4,12 +4,18 @@ class SocialLogin{
 
     data class Request(
         val accessToken: String,
-        val refreshToken: String
     )
 
 
-    data class Response(
-        val accessToken: String,
-        val refreshToken: String
-    )
+    sealed class Response{
+
+        data class Success(
+            val accessToken: String,
+            val refreshToken: String
+        ): Response()
+
+        data class UnRegistered(
+            val registerToken: String
+        ): Response()
+    }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/domain/enum/Provider.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/domain/enum/Provider.kt
@@ -1,0 +1,6 @@
+package com.asap.asapbackend.domain.user.domain.enum
+
+enum class Provider {
+    GOOGLE,
+    KAKAO
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/domain/model/User.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/domain/model/User.kt
@@ -1,0 +1,29 @@
+package com.asap.asapbackend.domain.user.domain.model
+
+import com.asap.asapbackend.domain.user.domain.enum.Provider
+import com.asap.asapbackend.global.domain.BaseDateEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Entity
+class User(
+    socialId: String,
+    provider: Provider,
+) : BaseDateEntity() {
+
+    @Column(
+        nullable = false,
+        columnDefinition = "varchar(255)"
+    )
+    val socialId: String = socialId
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        nullable = false,
+        columnDefinition = "varchar(100)"
+    )
+    val provider: Provider = provider
+
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/domain/repository/UserRepository.kt
@@ -1,0 +1,8 @@
+package com.asap.asapbackend.domain.user.domain.repository
+
+import com.asap.asapbackend.domain.user.domain.model.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRepository : JpaRepository<User, Long> {
+    fun findBySocialId(socialId: String): User?
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/domain/service/SocialLoginHandler.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/domain/service/SocialLoginHandler.kt
@@ -1,0 +1,17 @@
+package com.asap.asapbackend.domain.user.domain.service
+
+import com.asap.asapbackend.domain.user.domain.enum.Provider
+
+interface SocialLoginHandler{
+    val provider: Provider
+
+    fun handle(request: Request): Response
+
+    data class Request(
+        val accessToken: String
+    )
+
+    data class Response(
+        val socialId: String
+    )
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/domain/service/UserReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/domain/service/UserReader.kt
@@ -1,0 +1,16 @@
+package com.asap.asapbackend.domain.user.domain.service
+
+import com.asap.asapbackend.domain.user.domain.model.User
+import com.asap.asapbackend.domain.user.domain.repository.UserRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserReader(
+    private val userRepository: UserRepository
+) {
+
+    fun findBySocialIdOrNull(socialId: String): User?{
+        return userRepository.findBySocialId(socialId)
+    }
+
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthApi.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthApi.kt
@@ -4,10 +4,8 @@ object AuthApi {
 
     object V1{
         const val BASE_URL = "/api/v1/auth"
-
         const val SOCIAL_LOGIN = "$BASE_URL/login/{provider}"
         const val LOGOUT = "$BASE_URL/logout"
-
         const val REISSUE = "$BASE_URL/reissue"
     }
 

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthApi.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthApi.kt
@@ -1,0 +1,14 @@
+package com.asap.asapbackend.domain.user.presentation
+
+object AuthApi {
+
+    object V1{
+        const val BASE_URL = "/api/v1/auth"
+
+        const val SOCIAL_LOGIN = "$BASE_URL/login/{provider}"
+        const val LOGOUT = "$BASE_URL/logout"
+
+        const val REISSUE = "$BASE_URL/reissue"
+    }
+
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthController.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthController.kt
@@ -1,0 +1,19 @@
+package com.asap.asapbackend.domain.user.presentation
+
+import com.asap.asapbackend.domain.user.application.dto.SocialLogin
+import com.asap.asapbackend.domain.user.domain.enum.Provider
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthController {
+
+    @PostMapping(AuthApi.V1.SOCIAL_LOGIN)
+    fun socialLogin(@PathVariable provider: Provider,
+                    @RequestBody socialLoginRequest: SocialLogin.Request
+    ) : SocialLogin.Response{
+        return SocialLogin.Response("test access token", "test refresh token")
+    }
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthController.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthController.kt
@@ -1,19 +1,35 @@
 package com.asap.asapbackend.domain.user.presentation
 
+import com.asap.asapbackend.domain.user.application.AuthService
+import com.asap.asapbackend.domain.user.application.dto.Logout
+import com.asap.asapbackend.domain.user.application.dto.Reissue
 import com.asap.asapbackend.domain.user.application.dto.SocialLogin
 import com.asap.asapbackend.domain.user.domain.enum.Provider
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
-class AuthController {
+class AuthController(
+    private val authService: AuthService
+) {
 
+    // 멱등성 보장하지 않기 때문에 POST
     @PostMapping(AuthApi.V1.SOCIAL_LOGIN)
     fun socialLogin(@PathVariable provider: Provider,
                     @RequestBody socialLoginRequest: SocialLogin.Request
     ) : SocialLogin.Response{
-        return SocialLogin.Response("test access token", "test refresh token")
+        return authService.executeSocialLogin(socialLoginRequest, provider)
+    }
+
+    // 멱등성 보장하지 않기 때문에 POST
+    @PostMapping(AuthApi.V1.REISSUE)
+    fun reissueToken(@RequestBody reissueRequest: Reissue.Request) : Reissue.Response{
+        return authService.reissueToken(reissueRequest)
+    }
+
+    @DeleteMapping(AuthApi.V1.LOGOUT)
+    fun logout(
+        @RequestBody logoutRequest: Logout.Request
+    ) {
+        authService.logout(logoutRequest)
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthController.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/user/presentation/AuthController.kt
@@ -20,8 +20,9 @@ class AuthController(
         return authService.executeSocialLogin(socialLoginRequest, provider)
     }
 
-    // 멱등성 보장하지 않기 때문에 POST
-    @PostMapping(AuthApi.V1.REISSUE)
+    // 멱등성 보장하기 때문에 PUT
+    // 초반 동시성을 제외하고 이후 요청에 대한응답은 400으로 반환하기 때문에 멱등성 보장
+    @PutMapping(AuthApi.V1.REISSUE)
     fun reissueToken(@RequestBody reissueRequest: Reissue.Request) : Reissue.Response{
         return authService.reissueToken(reissueRequest)
     }

--- a/src/main/kotlin/com/asap/asapbackend/global/config/ConfigurationPropertiesConfig.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/config/ConfigurationPropertiesConfig.kt
@@ -1,6 +1,6 @@
 package com.asap.asapbackend.global.config
 
-import com.asap.asapbackend.global.security.jwt.JwtProperties
+import com.asap.asapbackend.global.jwt.JwtProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 

--- a/src/main/kotlin/com/asap/asapbackend/global/domain/BaseDateEntity.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/domain/BaseDateEntity.kt
@@ -1,0 +1,26 @@
+package com.asap.asapbackend.global.domain
+
+import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import java.time.LocalDateTime
+
+@MappedSuperclass
+open class BaseDateEntity: BaseEntity(){
+
+    lateinit var createdAt: LocalDateTime
+        private set
+    lateinit var updatedAt: LocalDateTime
+        private set
+
+    @PrePersist
+    fun prePersist(){
+        createdAt = LocalDateTime.now()
+        updatedAt = LocalDateTime.now()
+    }
+
+    @PreUpdate
+    fun update(){
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/asap/asapbackend/global/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/domain/BaseEntity.kt
@@ -1,0 +1,18 @@
+package com.asap.asapbackend.global.domain
+
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+
+@MappedSuperclass
+open class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+        get() {
+            // TODO : 영속화 관련 예외 정의하기
+            if(field == 0L) throw IllegalStateException("Entity must be persisted before using its id")
+            return field
+        }
+}

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtConst.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtConst.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 object JwtConst {
     const val TOKEN_ISSUER: String = "asap"

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtKeyFactory.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtKeyFactory.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtProperties.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtProperties.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtProvider.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 import com.asap.asapbackend.global.util.CacheManager
 import com.asap.asapbackend.global.util.LockManager

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtValidator.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/JwtValidator.kt
@@ -1,8 +1,8 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
-import com.asap.asapbackend.global.security.jwt.exception.ExpiredTokenException
-import com.asap.asapbackend.global.security.jwt.exception.InvalidTokenException
-import com.asap.asapbackend.global.security.jwt.exception.TokenErrorCode
+import com.asap.asapbackend.global.jwt.exception.ExpiredTokenException
+import com.asap.asapbackend.global.jwt.exception.InvalidTokenException
+import com.asap.asapbackend.global.jwt.exception.TokenErrorCode
 import io.jsonwebtoken.*
 import io.jsonwebtoken.jackson.io.JacksonDeserializer
 import io.jsonwebtoken.security.SignatureException

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/PrivateClaims.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/PrivateClaims.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/Token.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/Token.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 data class Token(
     val accessToken: String,

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/TokenType.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/TokenType.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 
 enum class TokenType {

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/ExpiredTokenException.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/ExpiredTokenException.kt
@@ -1,7 +1,7 @@
-package com.asap.asapbackend.global.security.jwt.exception
+package com.asap.asapbackend.global.jwt.exception
 
 import com.asap.asapbackend.global.exception.ErrorCode
 
-class InvalidTokenException(
+class ExpiredTokenException(
     override val errorCode: ErrorCode
 ): TokenException(errorCode)

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/InvalidTokenException.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/InvalidTokenException.kt
@@ -1,7 +1,7 @@
-package com.asap.asapbackend.global.security.jwt.exception
+package com.asap.asapbackend.global.jwt.exception
 
 import com.asap.asapbackend.global.exception.ErrorCode
 
-class ExpiredTokenException(
+class InvalidTokenException(
     override val errorCode: ErrorCode
 ): TokenException(errorCode)

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/TokenErrorCode.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/TokenErrorCode.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt.exception
+package com.asap.asapbackend.global.jwt.exception
 
 import com.asap.asapbackend.global.exception.ErrorCode
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/TokenException.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/jwt/exception/TokenException.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt.exception
+package com.asap.asapbackend.global.jwt.exception
 
 import com.asap.asapbackend.global.exception.BusinessException
 import com.asap.asapbackend.global.exception.ErrorCode

--- a/src/main/kotlin/com/asap/asapbackend/global/util/TransactionUtils.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/util/TransactionUtils.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.utils
+package com.asap.asapbackend.global.util
 
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/asap/asapbackend/global/utils/TransactionUtils.kt
+++ b/src/main/kotlin/com/asap/asapbackend/global/utils/TransactionUtils.kt
@@ -1,0 +1,42 @@
+package com.asap.asapbackend.global.utils
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class TransactionUtils(
+    _transactionHandler: TransactionHandler
+) {
+
+    init {
+        transactionHandler = _transactionHandler
+    }
+
+    companion object{
+        private lateinit var transactionHandler: TransactionHandler
+
+        fun <T> readable(func: () -> T): T {
+            return transactionHandler.readable { func() }
+        }
+
+        fun <T> writable(func: () -> T): T {
+            return transactionHandler.writable { func() }
+        }
+
+    }
+
+    @Component
+    class TransactionHandler{
+
+        @Transactional(readOnly = true)
+        fun <T> readable(func: () -> T): T {
+            return func()
+        }
+
+        @Transactional
+        fun <T> writable(func: () -> T): T {
+            return func()
+        }
+    }
+
+}

--- a/src/test/kotlin/com/asap/asapbackend/domain/user/presentation/AuthControllerTest.kt
+++ b/src/test/kotlin/com/asap/asapbackend/domain/user/presentation/AuthControllerTest.kt
@@ -1,0 +1,51 @@
+package com.asap.asapbackend.domain.user.presentation
+
+import com.asap.asapbackend.AbstractRestDocsConfigurer
+import com.asap.asapbackend.domain.user.application.dto.SocialLogin
+import com.asap.asapbackend.domain.user.domain.enum.Provider
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(AuthController::class)
+class AuthControllerTest : AbstractRestDocsConfigurer() {
+
+    @Test
+    @DisplayName("소셜 로그인")
+    fun socialLogin() {
+        //given
+        val provider = Provider.KAKAO
+        val requestAccessToken = "accessToken"
+        val requestRefreshToken = "refreshToken"
+        val socialLoginRequest = SocialLogin.Request(requestAccessToken, requestRefreshToken)
+        val request = RestDocumentationRequestBuilders.post(AuthApi.V1.SOCIAL_LOGIN, provider)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(socialLoginRequest))
+        //when
+        val result = mockMvc.perform(request)
+        //then
+        result.andExpect(status().isOk)
+            .andDo(
+                resultHandler.document(
+                    requestFields(
+                        fieldWithPath("accessToken").description("소셜 로그인 플랫폼에서 발급받은 accessToken"),
+                        fieldWithPath("refreshToken").description("소셜 로그인 플랫폼에서 발급받은 refreshToken")
+                    ),
+                    pathParameters(
+                        parameterWithName("provider").description("소셜 로그인 플랫폼(GOOGLE, KAKAO)")
+                    ),
+                    responseFields(
+                        fieldWithPath("accessToken").description("서버 접근을 위한 accessToken"),
+                        fieldWithPath("refreshToken").description("서버 접근을 위한 refreshToken")
+                    )
+                )
+
+            )
+    }
+}

--- a/src/test/kotlin/com/asap/asapbackend/domain/user/presentation/AuthControllerTest.kt
+++ b/src/test/kotlin/com/asap/asapbackend/domain/user/presentation/AuthControllerTest.kt
@@ -1,11 +1,15 @@
 package com.asap.asapbackend.domain.user.presentation
 
 import com.asap.asapbackend.AbstractRestDocsConfigurer
+import com.asap.asapbackend.domain.user.application.AuthService
+import com.asap.asapbackend.domain.user.application.dto.Reissue
 import com.asap.asapbackend.domain.user.application.dto.SocialLogin
 import com.asap.asapbackend.domain.user.domain.enum.Provider
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.payload.PayloadDocumentation.*
@@ -13,20 +17,29 @@ import org.springframework.restdocs.request.RequestDocumentation.parameterWithNa
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
+
+// TODO : FixtureMonkey로 변경하기
 @WebMvcTest(AuthController::class)
-class AuthControllerTest : AbstractRestDocsConfigurer() {
+class AuthControllerTest : AbstractRestDocsConfigurer(){
+
+    @MockBean
+    private lateinit var authService: AuthService
+
 
     @Test
-    @DisplayName("소셜 로그인")
-    fun socialLogin() {
+    @DisplayName("소셜 로그인시 사용자가 가입되어 있으면 accessToken, refreshToken을 반환한다.")
+    fun socialLoginWithRegisterUser() {
         //given
         val provider = Provider.KAKAO
         val requestAccessToken = "accessToken"
-        val requestRefreshToken = "refreshToken"
-        val socialLoginRequest = SocialLogin.Request(requestAccessToken, requestRefreshToken)
+        val socialLoginRequest = SocialLogin.Request(requestAccessToken)
+        val responseAccessToken = "success access token"
+        val responseRefreshToken = "success refresh token"
+        val socialLoginResponse = SocialLogin.Response.Success(responseAccessToken, responseRefreshToken)
         val request = RestDocumentationRequestBuilders.post(AuthApi.V1.SOCIAL_LOGIN, provider)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(socialLoginRequest))
+        given(authService.executeSocialLogin(socialLoginRequest, provider)).willReturn(socialLoginResponse)
         //when
         val result = mockMvc.perform(request)
         //then
@@ -35,7 +48,6 @@ class AuthControllerTest : AbstractRestDocsConfigurer() {
                 resultHandler.document(
                     requestFields(
                         fieldWithPath("accessToken").description("소셜 로그인 플랫폼에서 발급받은 accessToken"),
-                        fieldWithPath("refreshToken").description("소셜 로그인 플랫폼에서 발급받은 refreshToken")
                     ),
                     pathParameters(
                         parameterWithName("provider").description("소셜 로그인 플랫폼(GOOGLE, KAKAO)")
@@ -45,7 +57,94 @@ class AuthControllerTest : AbstractRestDocsConfigurer() {
                         fieldWithPath("refreshToken").description("서버 접근을 위한 refreshToken")
                     )
                 )
-
             )
     }
+
+    @Test
+    @DisplayName("소셜 로그인시 사용자가 가입되어 있지 않으면 registerToken을 반환한다.")
+    fun socialLoginWithUnRegisterUser() {
+        //given
+        val provider = Provider.KAKAO
+        val requestAccessToken = "accessToken"
+        val socialLoginRequest = SocialLogin.Request(requestAccessToken)
+        val responseRegisterToken = "register token"
+        val socialLoginResponse = SocialLogin.Response.UnRegistered(responseRegisterToken)
+        val request = RestDocumentationRequestBuilders.post(AuthApi.V1.SOCIAL_LOGIN, provider)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(socialLoginRequest))
+        given(authService.executeSocialLogin(socialLoginRequest, provider)).willReturn(socialLoginResponse)
+        //when
+        val result = mockMvc.perform(request)
+        //then
+        result.andExpect(status().isOk)
+            .andDo(
+                resultHandler.document(
+                    requestFields(
+                        fieldWithPath("accessToken").description("소셜 로그인 플랫폼에서 발급받은 accessToken"),
+                    ),
+                    pathParameters(
+                        parameterWithName("provider").description("소셜 로그인 플랫폼(GOOGLE, KAKAO)")
+                    ),
+                    responseFields(
+                        fieldWithPath("registerToken").description("회원가입 진행을 위한 token")
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("토큰 재발급시 accessToken, refreshToken을 반환한다.")
+    fun reissueToken() {
+        //given
+        val refreshToken = "refreshToken"
+        val reissueRequest = Reissue.Request(refreshToken)
+        val reissueAccessToken = "reissue access token"
+        val reissueRefreshToken = "reissue refresh token"
+        val reissueResponse = Reissue.Response(reissueAccessToken, reissueRefreshToken)
+        given(authService.reissueToken(reissueRequest)).willReturn(reissueResponse)
+        val request = RestDocumentationRequestBuilders.post(AuthApi.V1.REISSUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(reissueRequest))
+        //when
+        val result = mockMvc.perform(request)
+        //then
+        result.andExpect(status().isOk)
+            .andDo(
+                resultHandler.document(
+                    requestFields(
+                        fieldWithPath("refreshToken").description("재발급을 위한 refreshToken"),
+                    ),
+                    responseFields(
+                        fieldWithPath("accessToken").description("재발급된 accessToken"),
+                        fieldWithPath("refreshToken").description("재발급된 refreshToken")
+                    )
+                )
+            )
+    }
+
+
+    @Test
+    @DisplayName("로그아웃 요청시 성공한다.")
+    fun logout() {
+        //given
+        val refreshToken = "refreshToken"
+        val logoutRequest = Reissue.Request(refreshToken)
+        val request = RestDocumentationRequestBuilders.delete(AuthApi.V1.LOGOUT)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(logoutRequest))
+        //when
+        val result = mockMvc.perform(request)
+        //then
+        result.andExpect(status().isOk)
+            .andDo(
+                resultHandler.document(
+                    requestFields(
+                        fieldWithPath("refreshToken").description("로그아웃을 위한 refreshToken"),
+                    )
+                )
+            )
+    }
+
+
+
 }

--- a/src/test/kotlin/com/asap/asapbackend/domain/user/presentation/AuthControllerTest.kt
+++ b/src/test/kotlin/com/asap/asapbackend/domain/user/presentation/AuthControllerTest.kt
@@ -102,7 +102,7 @@ class AuthControllerTest : AbstractRestDocsConfigurer(){
         val reissueRefreshToken = "reissue refresh token"
         val reissueResponse = Reissue.Response(reissueAccessToken, reissueRefreshToken)
         given(authService.reissueToken(reissueRequest)).willReturn(reissueResponse)
-        val request = RestDocumentationRequestBuilders.post(AuthApi.V1.REISSUE)
+        val request = RestDocumentationRequestBuilders.put(AuthApi.V1.REISSUE)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(reissueRequest))
         //when

--- a/src/test/kotlin/com/asap/asapbackend/global/jwt/JwtProviderTest.kt
+++ b/src/test/kotlin/com/asap/asapbackend/global/jwt/JwtProviderTest.kt
@@ -1,4 +1,4 @@
-package com.asap.asapbackend.global.security.jwt
+package com.asap.asapbackend.global.jwt
 
 import com.asap.asapbackend.fixture.generateFixture
 import com.asap.asapbackend.generateBasicParser

--- a/src/testFixtures/kotlin/com/asap/asapbackend/AbstractRestDocsConfigurer.kt
+++ b/src/testFixtures/kotlin/com/asap/asapbackend/AbstractRestDocsConfigurer.kt
@@ -1,0 +1,47 @@
+package com.asap.asapbackend
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.context.annotation.Import
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import org.springframework.web.filter.CharacterEncodingFilter
+import java.nio.charset.StandardCharsets
+
+@AutoConfigureRestDocs
+@Import(RestDocsConfig::class)
+@ExtendWith(RestDocumentationExtension::class)
+abstract class AbstractRestDocsConfigurer(){
+
+    @Autowired
+    lateinit var resultHandler: RestDocumentationResultHandler
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun mockMvcSetup(
+        applicationContext: WebApplicationContext,
+        contextProvider: RestDocumentationContextProvider
+    ){
+        mockMvc=MockMvcBuilders.webAppContextSetup(applicationContext)
+            .apply<DefaultMockMvcBuilder>(
+                MockMvcRestDocumentation.documentationConfiguration(contextProvider).uris()
+                    .withScheme("https")
+            ).alwaysDo<DefaultMockMvcBuilder?>(resultHandler)
+            .addFilters<DefaultMockMvcBuilder?>(CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+            .build()
+    }
+
+}

--- a/src/testFixtures/kotlin/com/asap/asapbackend/RestDocsConfig.kt
+++ b/src/testFixtures/kotlin/com/asap/asapbackend/RestDocsConfig.kt
@@ -1,0 +1,17 @@
+package com.asap.asapbackend
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+
+@TestConfiguration
+class RestDocsConfig {
+
+    @Bean
+    fun restDocumentationResultHandler() = MockMvcRestDocumentation.document(
+        "{ClassName}/{methodName}",
+        Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+        Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+    )
+}


### PR DESCRIPTION
## 🗃 Issue

-  #6 

## 🔥 Task

- 소셜 로그인 api 스팩 정의
- 토큰 재발급 api 스팩 정의
- 로그인 api 스팩 정의
- 소셜 로그인, 토큰 재발급, 로그인 api 테스트 코드 작성
- 소셜 로그인, 토큰 재발급, 로그인 api 명세 추가
- 카카오 소셜 로그인 구현
- 트랜잭션 범위를 람다를 통해 지정할 수 있는 유틸 클래스 추가
- socailId, provider 컬럼으로가지는 User 엔티티 추가


## 📄 Reference

- 소셜 로그인 flow

```mermaid
sequenceDiagram
    actor client
    client ->> AuthController: 소셜 로그인 요청
    AuthController ->> AuthService: 소셜 로그인 메소드 호출
    AuthService ->> SocailLoginHandler: 요청 플랫폼을 통해 사용자 정보 조회 요청
    SocailLoginHandler -->> AuthService : 플랫폼 사용자 식별 id 반환
    AuthService ->> UserReader : 사용자 식별 id를 통해 사용자 조회
    UserReader -->> AuthService: 사용자 반환(null 아니면 not null)
    alt 사용자가 있을 때(not null)
        AuthService -->> AuthController: access token, refresh token 반환
    else 사용자가 가입되지 않을 때(null)
        AuthService -->> AuthController: 회원가입 진행을 위한 register token 반환
    end

    AuthController -->> client: 소셜로그인 응답 반환
  ```


- 멱등성 https://www.tosspayments.com/blog/articles/dev-1