### PR TITLE
feat: 대표 자녀 설정 및 조회 메소드 추가

### DIFF
--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/model/PrimaryChild.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/model/PrimaryChild.kt
@@ -1,0 +1,30 @@
+package com.asap.asapbackend.domain.child.domain.model
+
+import com.asap.asapbackend.global.domain.BaseDateEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+
+@Entity
+@Table(
+    indexes = [
+        Index(name = "idx_primary_child_user_id", columnList = "userId"),
+    ]
+)
+class PrimaryChild(
+    userId: Long,
+    childId: Long
+):BaseDateEntity() {
+
+    @Column(
+        unique = true,
+        nullable = false
+    )
+    val userId: Long = userId
+    @Column(
+        unique = true,
+        nullable = false
+    )
+    val childId: Long = childId
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/repository/PrimaryChildRepository.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/repository/PrimaryChildRepository.kt
@@ -1,0 +1,10 @@
+package com.asap.asapbackend.domain.child.domain.repository
+
+import com.asap.asapbackend.domain.child.domain.model.PrimaryChild
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PrimaryChildRepository: JpaRepository<PrimaryChild, Long> {
+    fun existsByUserId(userId: Long): Boolean
+
+    fun findByUserId(userId: Long): PrimaryChild?
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
@@ -1,14 +1,20 @@
 package com.asap.asapbackend.domain.child.domain.service
 
 import com.asap.asapbackend.domain.child.domain.model.Child
+import com.asap.asapbackend.domain.child.domain.model.PrimaryChild
 import com.asap.asapbackend.domain.child.domain.repository.ChildRepository
+import com.asap.asapbackend.domain.child.domain.repository.PrimaryChildRepository
 import org.springframework.stereotype.Service
 
 @Service
 class ChildAppender(
-    private val childRepository: ChildRepository
+    private val childRepository: ChildRepository,
+    private val primaryChildRepository: PrimaryChildRepository
 ) {
     fun appendChild(child: Child) {
+        if(primaryChildRepository.existsByUserId(child.parent.id).not()){
+            primaryChildRepository.save(PrimaryChild(child.parent.id, child.id))
+        }
         childRepository.save(child)
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildReader.kt
@@ -3,14 +3,28 @@ package com.asap.asapbackend.domain.child.domain.service
 import com.asap.asapbackend.domain.child.domain.exception.ChildException
 import com.asap.asapbackend.domain.child.domain.model.Child
 import com.asap.asapbackend.domain.child.domain.repository.ChildRepository
+import com.asap.asapbackend.domain.child.domain.repository.PrimaryChildRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class ChildReader(
-    private val childRepository: ChildRepository
+    private val childRepository: ChildRepository,
+    private val primaryChildRepository: PrimaryChildRepository
 ) {
     fun findAllByIds(childIds: Set<Long>): Set<Child> {
         return childRepository.findAllById(childIds).toSet()
+    }
+
+    fun findPrimaryChild(userId: Long): Child? {
+        return findChild {
+            primaryChildRepository.findByUserId(userId)?.let {
+                childRepository.findByIdOrNull(it.childId)
+            }
+        }
+    }
+
+    private fun findChild(function: () -> Child?): Child {
+        return function() ?: throw ChildException.ChildNotFoundException()
     }
 }


### PR DESCRIPTION
## 🗃 Issue

-  #50 

## 🔥 Task

- 대표 자녀 엔티티 추가 PrimaryChild
- 자녀 추가시 대표 자녀 레코드도 저장되도록 추가
- 자녀 조회시 대표 자녀로 조회할 수 있는 메소드 추가

## 📄 Reference

- None
