### PR TITLE
refactor: #50 primarychild 수정

### DIFF
--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/model/PrimaryChild.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/model/PrimaryChild.kt
@@ -1,17 +1,27 @@
 package com.asap.asapbackend.domain.child.domain.model
 
-import com.asap.asapbackend.domain.user.domain.model.User
 import com.asap.asapbackend.global.domain.BaseDateEntity
 import jakarta.persistence.*
 
 @Entity
+@Table(
+    indexes = [
+        Index(name = "idx_primary_child_user_id", columnList = "userId"),
+    ]
+)
 class PrimaryChild(
-    user: User,
-    child: Child
+    userId: Long,
+    childId: Long
 ):BaseDateEntity() {
-    @ManyToOne(fetch = FetchType.LAZY)
-    val user = user
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    val child = child
+    @Column(
+        unique = true,
+        nullable = false
+    )
+    val userId: Long = userId
+    @Column(
+        unique = true,
+        nullable = false
+    )
+    val childId: Long = childId
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/model/PrimaryChild.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/model/PrimaryChild.kt
@@ -1,30 +1,17 @@
 package com.asap.asapbackend.domain.child.domain.model
 
+import com.asap.asapbackend.domain.user.domain.model.User
 import com.asap.asapbackend.global.domain.BaseDateEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Index
-import jakarta.persistence.Table
+import jakarta.persistence.*
 
 @Entity
-@Table(
-    indexes = [
-        Index(name = "idx_primary_child_user_id", columnList = "userId"),
-    ]
-)
 class PrimaryChild(
-    userId: Long,
-    childId: Long
+    user: User,
+    child: Child
 ):BaseDateEntity() {
+    @ManyToOne(fetch = FetchType.LAZY)
+    val user = user
 
-    @Column(
-        unique = true,
-        nullable = false
-    )
-    val userId: Long = userId
-    @Column(
-        unique = true,
-        nullable = false
-    )
-    val childId: Long = childId
+    @ManyToOne(fetch = FetchType.LAZY)
+    val child = child
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
@@ -16,6 +16,5 @@ class ChildAppender(
             childRepository.save(child)
             primaryChildRepository.save(PrimaryChild(child.parent, child))
         }
-        childRepository.save(child)
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
@@ -13,7 +13,8 @@ class ChildAppender(
 ) {
     fun appendChild(child: Child) {
         if(primaryChildRepository.existsByUserId(child.parent.id).not()){
-            primaryChildRepository.save(PrimaryChild(child.parent.id, child.id))
+            childRepository.save(child)
+            primaryChildRepository.save(PrimaryChild(child.parent, child))
         }
         childRepository.save(child)
     }

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildAppender.kt
@@ -12,9 +12,9 @@ class ChildAppender(
     private val primaryChildRepository: PrimaryChildRepository
 ) {
     fun appendChild(child: Child) {
+        childRepository.save(child)
         if(primaryChildRepository.existsByUserId(child.parent.id).not()){
-            childRepository.save(child)
-            primaryChildRepository.save(PrimaryChild(child.parent, child))
+            primaryChildRepository.save(PrimaryChild(child.parent.id, child.id))
         }
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildReader.kt
@@ -19,7 +19,7 @@ class ChildReader(
     fun findPrimaryChild(userId: Long): Child? {
         return findChild {
             primaryChildRepository.findByUserId(userId)?.let {
-                childRepository.findByIdOrNull(it.childId)
+                childRepository.findByIdOrNull(it.child.id)
             }
         }
     }

--- a/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/child/domain/service/ChildReader.kt
@@ -19,7 +19,7 @@ class ChildReader(
     fun findPrimaryChild(userId: Long): Child? {
         return findChild {
             primaryChildRepository.findByUserId(userId)?.let {
-                childRepository.findByIdOrNull(it.child.id)
+                childRepository.findByIdOrNull(it.childId)
             }
         }
     }

--- a/src/main/kotlin/com/asap/asapbackend/domain/classroom/domain/model/Classroom.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/classroom/domain/model/Classroom.kt
@@ -36,7 +36,7 @@ class Classroom(
     val school: School = school
 
 
-    @OneToMany(mappedBy = "classroom")
+    @OneToMany(mappedBy = "classroom", cascade = [CascadeType.ALL])
     val childClassroomSet: MutableSet<ChildClassroom> = mutableSetOf()
 
     @OneToMany(mappedBy = "classroom", cascade = [CascadeType.ALL])


### PR DESCRIPTION
## 🗃 Issue

- Close #50 

## 🔥 Task
- 유저 회원가입시 
{
    "errorCode": "DEFAULT-001",
    "message": "잘못된 속성입니다."
}
가 뜨는 에러 발생
```
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] org.hibernate.orm.sql.ast.create         : Registration of TableGroup [StandardTableGroup(com.asap.asapbackend.domain.child.domain.model.PrimaryChild(193283567448800))] with identifierForTableGroup [com.asap.asapbackend.domain.child.domain.model.PrimaryChild] for NavigablePath [com.asap.asapbackend.domain.child.domain.model.PrimaryChild] 
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.h.q.sqm.sql.BaseSqmToSqlAstConverter   : Determining mapping-model type for SqmParameter : org.hibernate.query.sqm.tree.expression.SqmJpaCriteriaParameterWrapper@48bc84a0
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.h.q.sqm.sql.BaseSqmToSqlAstConverter   : Determining mapping-model type for SqmPath : SqmBasicValuedSimplePath(com.asap.asapbackend.domain.child.domain.model.PrimaryChild(193283567448800).userId) 
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] org.hibernate.orm.results.graph.AST      : DomainResult Graph:
 \-BasicResult [com.asap.asapbackend.domain.child.domain.model.PrimaryChild(193283567448800).id]

2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] org.hibernate.orm.sql.ast.tree           : SQL AST Tree:
    SelectStatement {
      FromClause {
        StandardTableGroup (pc1 : com.asap.asapbackend.domain.child.domain.model.PrimaryChild(193283567448800)) {
          primaryTableReference : primary_child as pc1_0
        }
      }
    }

2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.h.e.i.AbstractFlushingEventListener    : Processing flush-time cascades
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.h.e.i.AbstractFlushingEventListener    : Dirty checking collections
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.h.e.i.AbstractFlushingEventListener    : Flushed: 0 insertions, 0 updates, 0 deletions to 1 objects
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.h.e.i.AbstractFlushingEventListener    : Flushed: 0 (re)creations, 0 updates, 0 removals to 0 collections
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.hibernate.internal.util.EntityPrinter  : Listing entities:
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.hibernate.internal.util.EntityPrinter  : com.asap.asapbackend.domain.user.domain.model.User{createdAt=2024-05-13T23:45:03.553997200, agreement=component[marketing,privacyPolicy,termsOfService]{marketing=false, privacyPolicy=true, termsOfService=true}, phoneNumber=component[number]{number=01011112222}, id=23, socialInfo=component[provider,socialId]{provider=KAKAO, socialId=3479284962}, updatedAt=2024-05-13T23:45:03.553997200}
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] org.hibernate.orm.sql.exec               : Skipping reading Query result cache data: cache-enabled = false, cache-mode = NORMAL
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] org.hibernate.orm.results                : Initializer list is empty
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] org.hibernate.SQL                        : select pc1_0.id from primary_child pc1_0 where pc1_0.user_id=? limit ?
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.s.orm.jpa.JpaTransactionManager        : Initiating transaction rollback
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.s.orm.jpa.JpaTransactionManager        : Rolling back JPA transaction on EntityManager [SessionImpl(450131257<open>)]
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.h.e.t.internal.TransactionImpl         : rolling back
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.s.orm.jpa.JpaTransactionManager        : Closing JPA EntityManager [SessionImpl(450131257<open>)] after transaction
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] .m.m.a.ExceptionHandlerExceptionResolver : Using @ExceptionHandler com.asap.asapbackend.global.exception.ExceptionHandler#handleException(BusinessException)
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.s.w.s.m.m.a.HttpEntityMethodProcessor  : Using 'application/json', given [*/*] and supported [application/json, application/*+json]
2024-05-13 23:45:03 [DEBUG] --- [nio-8080-exec-2] o.s.w.s.m.m.a.HttpEntityMethodProcessor  : Writing [ErrorResponse(errorCode=DEFAULT-001, message=잘못된 속성입니다.)]
```
- primarychild 수정
- primarychild에 save 하기 전에 새로 만든 child를 저장

## 📄 Reference

- None
