### PR TITLE
할일 삭제 API

### DIFF
--- a/src/docs/asciidoc/Todo.adoc
+++ b/src/docs/asciidoc/Todo.adoc
@@ -5,8 +5,11 @@
 === 할일 추가
 operation::TodoControllerTest/createTodo[]
 
-=== 전체 할일 조회
+=== 기한이 남은 전체 할일 조회
 operation::TodoControllerTest/getTodo[]
 
-=== todo 상태 변경
+=== 할일 상태 변경
 operation::TodoControllerTest/changeStatus[]
+
+=== 할일 삭제
+operation::TodoControllerTest/deleteTodo[]

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
@@ -49,18 +49,19 @@ class TodoService(
         val userId = getCurrentUserId()
         val childId = childReader.findPrimaryChild(userId).id
         val todo = todoReader.findByIdOrNull(todoId)
-        if(todoReader.findAllByChildId(childId).contains(todo)){
+        if (todoReader.findAllByChildId(childId).contains(todo)) {
             todoModifier.changeTodoStatus(todo)
         }
     }
 
     @Transactional
-    fun deleteTodo(todoId: Long){
+    fun deleteTodo(todoId: Long) {
         val userId = getCurrentUserId()
         val childId = childReader.findPrimaryChild(userId).id
-        val todo = todoReader.findByIdOrNull(todoId)
-        if(todoReader.findAllByChildId(childId).contains(todo)){
-            todoRemover.delete(todo)
+        todoReader.findByIdOrNull(todoId)?.let { todo ->
+            if (todoReader.findAllByChildId(childId).contains(todo) && !todo.isAssigned) {
+                todoRemover.delete(todo)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
@@ -36,10 +36,10 @@ class TodoService(
         todoAppender.appendTodo(todo)
     }
 
-    fun getTodoDueAfterDate(day: LocalDate): GetTodo.Response {
+    fun getTodoDueAfterDate(date: LocalDate): GetTodo.Response {
         val userId = getCurrentUserId()
         val childId = childReader.findPrimaryChild(userId).id
-        val todoDataList = todoReader.findTodoDueAfterDayByChildId(childId, day)
+        val todoDataList = todoReader.findTodoDueAfterDayByChildId(childId, date)
         val todoList = GetTodo().toTodoInfo(todoDataList)
         return GetTodo.Response(todoList)
     }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
@@ -47,19 +47,20 @@ class TodoService(
     @Transactional
     fun changeStatus(todoId: Long) {
         val userId = getCurrentUserId()
-        val childId = childReader.findPrimaryChild(userId).id
-        val todo = todoReader.findByIdOrNull(todoId)
-        if (todoReader.findAllByChildId(childId).contains(todo)) {
-            todoModifier.changeTodoStatus(todo)
+        val todoList = todoReader.findAllByUserId(userId)
+        todoReader.findByIdOrNull(todoId)?.let { todo->
+            if (todoList.contains(todo)) {
+                todoModifier.changeTodoStatus(todo)
+            }
         }
     }
 
     @Transactional
     fun deleteTodo(todoId: Long) {
         val userId = getCurrentUserId()
-        val childId = childReader.findPrimaryChild(userId).id
+        val todoList = todoReader.findAllByUserId(userId)
         todoReader.findByIdOrNull(todoId)?.let { todo ->
-            if (todoReader.findAllByChildId(childId).contains(todo) && !todo.isAssigned) {
+            if (todoList.contains(todo) && !todo.isAssigned) {
                 todoRemover.delete(todo)
             }
         }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/application/TodoService.kt
@@ -7,6 +7,7 @@ import com.asap.asapbackend.domain.todo.domain.model.Todo
 import com.asap.asapbackend.domain.todo.domain.service.TodoAppender
 import com.asap.asapbackend.domain.todo.domain.service.TodoModifier
 import com.asap.asapbackend.domain.todo.domain.service.TodoReader
+import com.asap.asapbackend.domain.todo.domain.service.TodoRemover
 import com.asap.asapbackend.global.security.getCurrentUserId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,7 +19,8 @@ class TodoService(
     private val todoAppender: TodoAppender,
     private val childReader: ChildReader,
     private val todoReader: TodoReader,
-    private val todoModifier: TodoModifier
+    private val todoModifier: TodoModifier,
+    private val todoRemover: TodoRemover
 ) {
     @Transactional
     fun createTodo(request: CreateTodo.Request) {
@@ -34,16 +36,31 @@ class TodoService(
         todoAppender.appendTodo(todo)
     }
 
-    fun getTodoUntilDeadLine(deadline: LocalDate): GetTodo.Response {
+    fun getTodoDueAfterDate(day: LocalDate): GetTodo.Response {
         val userId = getCurrentUserId()
         val childId = childReader.findPrimaryChild(userId).id
-        val todoDataList = todoReader.findByChildIdUntilDeadline(childId, deadline)
+        val todoDataList = todoReader.findTodoDueAfterDayByChildId(childId, day)
         val todoList = GetTodo().toTodoInfo(todoDataList)
         return GetTodo.Response(todoList)
     }
 
     @Transactional
     fun changeStatus(todoId: Long) {
-        todoModifier.changeStatus(todoId)
+        val userId = getCurrentUserId()
+        val childId = childReader.findPrimaryChild(userId).id
+        val todo = todoReader.findByIdOrNull(todoId)
+        if(todoReader.findAllByChildId(childId).contains(todo)){
+            todoModifier.changeTodoStatus(todo)
+        }
+    }
+
+    @Transactional
+    fun deleteTodo(todoId: Long){
+        val userId = getCurrentUserId()
+        val childId = childReader.findPrimaryChild(userId).id
+        val todo = todoReader.findByIdOrNull(todoId)
+        if(todoReader.findAllByChildId(childId).contains(todo)){
+            todoRemover.delete(todo)
+        }
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/application/dto/DeleteTodo.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/application/dto/DeleteTodo.kt
@@ -1,0 +1,7 @@
+package com.asap.asapbackend.domain.todo.application.dto
+
+class DeleteTodo {
+    data class Request (
+        val todoId: Long
+    )
+}

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/repository/TodoRepository.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/repository/TodoRepository.kt
@@ -2,10 +2,17 @@ package com.asap.asapbackend.domain.todo.domain.repository
 
 import com.asap.asapbackend.domain.todo.domain.model.Todo
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.time.LocalDate
 
 interface TodoRepository : JpaRepository<Todo, Long> {
     fun findAllByChildIdAndDeadlineAfter(childId: Long, deadline: LocalDate): List<Todo>
 
-    fun findAllByChildId(childId: Long): List<Todo>
+    @Query("""
+        select t
+        from Todo t
+        join fetch t.child
+        join PrimaryChild p on p.childId = t.child.id and p.userId = :userId
+    """)
+    fun findAllByUserId(userId: Long): List<Todo>
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/repository/TodoRepository.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/repository/TodoRepository.kt
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDate
 
 interface TodoRepository : JpaRepository<Todo, Long> {
-    fun findAllByChildIdAndDeadlineBefore(childId: Long, deadline: LocalDate): List<Todo>
+    fun findAllByChildIdAndDeadlineAfter(childId: Long, deadline: LocalDate): List<Todo>
+
+    fun findAllByChildId(childId: Long): List<Todo>
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoModifier.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoModifier.kt
@@ -8,10 +8,8 @@ import org.springframework.stereotype.Service
 class TodoModifier(
     private val todoRepository: TodoRepository,
 ){
-    fun changeTodoStatus(todo: Todo?) {
-        todo?.let {
-            it.changeStatus()
-            todoRepository.save(it)
-        }
+    fun changeTodoStatus(todo: Todo) {
+        todo.changeStatus()
+        todoRepository.save(todo)
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoReader.kt
@@ -10,8 +10,8 @@ import java.time.LocalDate
 class TodoReader(
     private val todoRepository: TodoRepository
 ) {
-    fun findTodoDueAfterDayByChildId(childId: Long, deadline: LocalDate): List<Todo> {
-        return todoRepository.findAllByChildIdAndDeadlineAfter(childId, deadline.minusDays(1))
+    fun findTodoDueAfterDayByChildId(childId: Long, date: LocalDate): List<Todo> {
+        return todoRepository.findAllByChildIdAndDeadlineAfter(childId, date.minusDays(1))
     }
 
     fun findAllByChildId(todoId: Long) : List<Todo> {

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoReader.kt
@@ -2,6 +2,7 @@ package com.asap.asapbackend.domain.todo.domain.service
 
 import com.asap.asapbackend.domain.todo.domain.model.Todo
 import com.asap.asapbackend.domain.todo.domain.repository.TodoRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -9,7 +10,15 @@ import java.time.LocalDate
 class TodoReader(
     private val todoRepository: TodoRepository
 ) {
-    fun findByChildIdUntilDeadline(childId: Long, deadline: LocalDate): List<Todo> {
-        return todoRepository.findAllByChildIdAndDeadlineBefore(childId, deadline.plusDays(1))
+    fun findTodoDueAfterDayByChildId(childId: Long, deadline: LocalDate): List<Todo> {
+        return todoRepository.findAllByChildIdAndDeadlineAfter(childId, deadline.minusDays(1))
+    }
+
+    fun findAllByChildId(todoId: Long) : List<Todo> {
+        return todoRepository.findAllByChildId(todoId)
+    }
+
+    fun findByIdOrNull(todoId: Long) : Todo? {
+        return todoRepository.findByIdOrNull(todoId)
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoReader.kt
@@ -14,11 +14,11 @@ class TodoReader(
         return todoRepository.findAllByChildIdAndDeadlineAfter(childId, date.minusDays(1))
     }
 
-    fun findAllByChildId(todoId: Long) : List<Todo> {
-        return todoRepository.findAllByChildId(todoId)
-    }
-
     fun findByIdOrNull(todoId: Long) : Todo? {
         return todoRepository.findByIdOrNull(todoId)
+    }
+
+    fun findAllByUserId(userId: Long) : List<Todo> {
+        return todoRepository.findAllByUserId(userId)
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoRemover.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoRemover.kt
@@ -5,13 +5,12 @@ import com.asap.asapbackend.domain.todo.domain.repository.TodoRepository
 import org.springframework.stereotype.Service
 
 @Service
-class TodoModifier(
-    private val todoRepository: TodoRepository,
-){
-    fun changeTodoStatus(todo: Todo?) {
+class TodoRemover(
+    private val todoRepository: TodoRepository
+) {
+    fun delete(todo: Todo?){
         todo?.let {
-            it.changeStatus()
-            todoRepository.save(it)
+            todoRepository.delete(it)
         }
     }
 }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoRemover.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/domain/service/TodoRemover.kt
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Service
 class TodoRemover(
     private val todoRepository: TodoRepository
 ) {
-    fun delete(todo: Todo?){
-        todo?.let {
+    fun delete(todo: Todo){
+        todo.let {
             todoRepository.delete(it)
         }
     }

--- a/src/main/kotlin/com/asap/asapbackend/domain/todo/presentation/TodoController.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/todo/presentation/TodoController.kt
@@ -3,6 +3,7 @@ package com.asap.asapbackend.domain.todo.presentation
 import com.asap.asapbackend.domain.todo.application.TodoService
 import com.asap.asapbackend.domain.todo.application.dto.ChangeTodoStatus
 import com.asap.asapbackend.domain.todo.application.dto.CreateTodo
+import com.asap.asapbackend.domain.todo.application.dto.DeleteTodo
 import com.asap.asapbackend.domain.todo.application.dto.GetTodo
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
@@ -17,12 +18,17 @@ class TodoController(
     }
 
     @GetMapping(TodoApi.V1.BASE_URL)
-    fun getTodo(@RequestParam deadline: LocalDate): GetTodo.Response {
-        return todoService.getTodoUntilDeadLine(deadline)
+    fun getTodo(@RequestParam date: LocalDate): GetTodo.Response {
+        return todoService.getTodoDueAfterDate(date)
     }
 
     @PutMapping(TodoApi.V1.BASE_URL)
     fun changeStatus(@RequestBody request: ChangeTodoStatus.Request){
         todoService.changeStatus(request.todoId)
+    }
+
+    @DeleteMapping(TodoApi.V1.BASE_URL)
+    fun deleteTodo(@RequestBody request: DeleteTodo.Request) {
+        todoService.deleteTodo(request.todoId)
     }
 }


### PR DESCRIPTION
## 🗃 Issue

- Close #89

## 🔥 Task

- 할일 삭제 API (본인이 한것만 가능, 선생님이 만든 투두는 삭제 불가능)
- 할일 id로 상태 변경 토큰 검증 추가
- 할일 deadline까지 전체 불러오기 -> 할일 조회한 날짜보다 기한이 남은 할일 불러오기

## 📄 Reference

- None
