### PR TITLE
fix: 가정통신문 가져올 떄 정렬을 id가 아닌 index를 통해 가져올 수 있도록 변경

### DIFF
--- a/src/main/kotlin/com/asap/asapbackend/domain/announcement/domain/repository/SchoolAnnouncementRepository.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/announcement/domain/repository/SchoolAnnouncementRepository.kt
@@ -24,7 +24,7 @@ interface SchoolAnnouncementRepository : JpaRepository<SchoolAnnouncement, Long>
         join sa.schoolAnnouncementPage as sap on sap.id = sa.schoolAnnouncementPage.id
         join sap.school as s on s.id = sap.school.id
         join Classroom as c on c.school.id = s.id and c.id = :classroomId
-        ORDER BY sa.id DESC
+        ORDER BY sa.idx DESC
     """
     )
     fun findAllByClassroomId(classroomId: Long, pageable: Pageable): Page<SchoolAnnouncement>

--- a/src/main/kotlin/com/asap/asapbackend/domain/announcement/domain/service/SchoolAnnouncementReader.kt
+++ b/src/main/kotlin/com/asap/asapbackend/domain/announcement/domain/service/SchoolAnnouncementReader.kt
@@ -36,7 +36,7 @@ class SchoolAnnouncementReader(
             PageRequest.of(
                 pageable.pageNumber,
                 pageable.pageSize,
-                Sort.by(Sort.Direction.DESC, "id")
+                Sort.by(Sort.Direction.DESC, "idx")
             )
         )
     }


### PR DESCRIPTION
## 🗃 Issue


## 🔥 Task

- 가정통신문 가져올 떄 정렬을 id가 아닌 index를 통해 가져올 수 있도록 변경

## 📄 Reference

- None
